### PR TITLE
docs: SEO pass - titles, troubleshooting split, tool comparisons

### DIFF
--- a/.dev/active/01-docs-seo/context.md
+++ b/.dev/active/01-docs-seo/context.md
@@ -1,0 +1,97 @@
+# Context: Docs Site SEO — zerv
+
+Companion to a future `tasks.md` (checklist). This file holds everything an agent needs to plan SEO work: verified live findings, known bug classes, transferable decisions from the bakefile repo's completed SEO pass, and the opportunities specific to this repo. Dates are absolute. Verify anything marked "verify" against the live site before acting — this reflects 2026-08-24 state.
+
+## Project facts
+
+- Repo: `github.com/wislertt/zerv`, main branch `main`.
+- Product: CLI that generates version strings from Git state (tags, distance, branch, dirtiness). Runs next to semantic-release: semantic-release owns releases on main, zerv versions every other branch/build/dirty tree.
+- Tagline: "Dynamic versioning from git. Every commit gets its version."
+- **Dual distribution, two different package names**: Rust crate `zerv` on crates.io, Python package `zerv-version` on PyPI (wheel ships a Rust extension + `import zerv` binding). Also install script and pre-built binaries on GitHub Releases.
+- CLI: `zerv` with subcommands `flow`, `version`, `check`, `render`.
+- Author: Wisaroot Lertthaweedech (`wisl.dev`). Same author as bakefile and leetcode-py.
+- Docs: Mintlify site at `https://zerv.wisl.dev` (custom domain; default deployment host `zerv.mintlify.app`).
+- Separate demo repo exists: `github.com/wislertt/zerv-flow` (linked from docs footer) — an additional backlink/landing surface.
+
+## Docs stack and conventions
+
+- Mintlify, `docs/docs.json`. Theme `mint`. Site name `zerv` (rendered title suffix ` - zerv`, 7 chars, so frontmatter titles can run up to ~53 chars).
+- 17 pages: index, 3 getting-started, 5 concepts (flow, version, schema-system, formats-and-templates, config-file), 2 cicd (github-actions, semantic-release), 5 cli reference, 1 troubleshooting hub.
+- `docs/skill.md` hand-written, served at `/skill.md`, overrides Mintlify's auto-generated file. Do not delete, no MDX-only components.
+- `markdown.instructions` in docs.json injected into `llms.txt` / exports. Notable instruction: "Examples on this site are backed by integration tests; copy them verbatim" and exact flag names (`--output-template`, `--dirty` takes no value).
+- Docs verification: `bake docs-check` (bakefile.py defines `docs_check` → runs `mintlify broken-links` in `docs/`). `bake docs` runs the dev server.
+
+## Verified live state (2026-08-24)
+
+Checked directly against production:
+
+- `robots.txt`: Mintlify default, clean. AI bots allowed, `Content-Signal: ai-train=yes, search=yes, ai-input=yes`. Do not replace.
+- `sitemap.xml`: auto-generated, 17 pages, fresh `lastmod`.
+- `llms.txt`: HTTP 200.
+- Canonical set globally (`https://zerv.wisl.dev`).
+- Organization schema `sameAs` includes GitHub, PyPI, crates.io, wisl.dev (four sources — better than most).
+- Custom domain serves `/img/brand/*` (og card asset returns 200).
+- README links deeply into docs (flow, version, formats, semantic-release, why-zerv, installation).
+
+## Known bugs (same class as bakefile + leetcode-py, verified live 2026-08-24)
+
+1. **Duplicated title tag.** Homepage renders `<title>zerv - zerv</title>` (page title + site name identical). Fix: keyword title in `docs/index.mdx`, suffix carries brand. Candidate direction: "Git-based dynamic versioning CLI" phrasing — planning agent picks final wording.
+2. **og:image resolves to wrong host.** Meta emits `https://zerv.mintlify.app/img/brand/og-card-light.png` because `seo.metatags.og:image` is a relative path. Fix: absolute URL `https://zerv.wisl.dev/img/brand/og-card-light.png` (asset verified serving on custom domain).
+3. **Duplicated title on `cli/zerv`.** Title "zerv" renders `zerv - zerv`. Same fix bakefile used for its CLI page ("bakefile CLI").
+4. **Product-label titles.** "Installation", "Quickstart", "Troubleshooting", "Flow", "Version", "Config file" are labels, not queries. Same fix pattern: query-shaped titles + `sidebarTitle` where long.
+
+## Keyword space specific to this repo
+
+zerv competes in the "version from git" niche. Real query targets and who owns them now:
+
+- "semantic-release alternative" / running versioning beside semantic-release — `getting-started/why-zerv` + `cicd/semantic-release` already target this. Strongest existing surface.
+- "setuptools-scm alternative", "git describe alternative" — why-zerv comparison covers semantic-release, setuptools-scm, git describe (per README). Verify the page sections match all three.
+- **dunamai is not mentioned** in README's comparison list. dunamai is the most-used Python "version from git" library and likely owns the head terms ("python version from git", "pep440 from git"). Planning agent should evaluate adding it to the comparison (honest content only).
+- Long-tail: "version every commit", "version ci artifacts", "calver from git", "pep440 from git tags", "prerelease versioning feature branches".
+- Format keywords already have concept pages: SemVer, PEP440, CalVer, Tera templates (`concepts/formats-and-templates`).
+
+## Troubleshooting split opportunity
+
+`troubleshooting/index.mdx` has 9 H2 sections on one page — same shape bakefile had before its split. Errors from a versioning CLI are exact strings devs paste into Google (schema errors, config errors, git state errors). Same treatment: per-error pages with the exact error string as title, `sidebarTitle` short, hub links all. Thin/behavioral sections stay on the hub. (Read the actual sections before splitting — count of error-string sections vs behavioral ones determines page count.)
+
+## Measurement status (head start — mostly done)
+
+- GSC **Domain property `wisl.dev` verified 2026-08-24** via DNS TXT at Spaceship registrar. Domain property covers ALL subdomains — `zerv.wisl.dev` already verified. No new verification needed.
+- Bing Webmaster imported from GSC same day (covers Bing + DuckDuckGo + Yahoo).
+- **Pending:** submit `https://zerv.wisl.dev/sitemap.xml` in GSC (Sitemaps page); confirm Bing copied it via import.
+- **Pending:** GSC baseline (~2 weeks after sitemap submit): indexed pages, impressions, queries.
+
+## Transferable decisions from the bakefile SEO pass (2026-08-24, same author, same Mintlify setup)
+
+Applied and verified on bakefile.wisl.dev — reuse the patterns:
+
+- Homepage/landing `title` frontmatter = keywords, site-name suffix carries brand. Never put the brand word in the title when the suffix already appends it.
+- `sidebarTitle` frontmatter decouples long SEO titles from sidebar labels. Mintlify supports it natively.
+- `og:image` must be absolute; relative resolves against the mintlify.app host.
+- Query-shaped H2s on comparison pages ("X vs Y") match comparison queries. FAQ sections only with genuinely matching Q&A.
+- Troubleshooting: per-error pages, exact error string as title, hub links with error strings as anchors.
+- Internal linking: no orphan pages (footer/sidebar don't count — content links only), first-mention descriptive anchors, both directions.
+- Titles: unique, 50–60 chars rendered (including the ` - zerv` suffix).
+- Verification: `bake docs-check` after every docs edit; `curl -s <url> | grep '<title>'` after deploy.
+
+## Off-repo SEO context (separate track, informational)
+
+- No blog on the docs site (author decision). Articles live on wisl.dev (planned Astro blog), link into all docs sites. Cross-posting to Medium/dev.to only with canonical → wisl.dev.
+- Backlink surfaces this repo uniquely has: crates.io page, PyPI `zerv-version` page, the separate `zerv-flow` demo repo, GitHub Releases. Launch venues for this niche: r/rust, r/python HN threads on release tooling, semantic-release discussions.
+- Both competitor keywords (setuptools-scm, semantic-release ecosystems) have active communities where honest answers earn links.
+
+## Verification commands
+
+```bash
+bake docs-check                                            # broken links
+curl -s https://zerv.wisl.dev/ | grep '<title>'           # rendered title
+curl -s https://zerv.wisl.dev/ | grep 'og:image'          # og image host
+curl -s https://zerv.wisl.dev/sitemap.xml | grep -c '<loc>'  # page count
+```
+
+## Non-goals (decided, do not relitigate)
+
+- No blog section on the docs site.
+- No custom `robots.txt` / `sitemap.xml` (Mintlify defaults correct).
+- No structured-data changes beyond Mintlify's automatic JSON-LD + existing organization block.
+- Not moving docs off the subdomain.

--- a/.dev/active/01-docs-seo/tasks.md
+++ b/.dev/active/01-docs-seo/tasks.md
@@ -1,0 +1,98 @@
+# Tasks: Docs Site SEO — zerv
+
+Checklist companion to `context.md`. Decisions locked 2026-08-24. All repo work ships as **one PR**.
+
+## Locked decisions
+
+- Homepage title: `Dynamic versioning from git for every commit` (45 chars; 52 rendered with ` - zerv` suffix)
+- dunamai: add honest comparison section to `getting-started/why-zerv`
+- Troubleshooting: split 5 error-string sections into standalone pages; hub keeps 4 behavioral sections
+- PR shape: single PR for all repo changes (matches docs-site build precedent)
+- Non-goals: unchanged, see `context.md` (no blog, no custom robots/sitemap, no structured-data changes, subdomain stays)
+- No further llms.txt/GEO work: Google officially ignores it (June 2026 guidance); `skill.md` is the one AI-facing asset worth keeping
+
+## Phase A — meta fixes
+
+- [x] A1. `docs/docs.json`: `seo.metatags.og:image` → `https://zerv.wisl.dev/img/brand/og-card-light.png` (absolute; relative resolves against mintlify.app host)
+- [x] A2. `docs/index.mdx`: `title` → `Dynamic versioning from git for every commit`
+- [x] A3. `docs/cli/zerv.mdx`: `title` → query-shaped (candidate: `zerv CLI commands and global flags`), keep short `sidebarTitle`
+- [x] A4. Label titles → query-shaped; `sidebarTitle` keeps the short label. Candidates below — finalize wording at implementation, keep rendered title (incl. ` - zerv` suffix) between 50–60 chars where possible:
+
+    Final wording (rendered chars incl. suffix): Installation → `Install zerv from PyPI, crates.io, or binaries` (53); Quickstart → `zerv quickstart: your first version from git` (50); Flow → `zerv flow: branch-based versioning automation` (53); Version → `zerv version: manual versioning pipeline` (47); Config file → `zerv.toml config file: discovery and precedence` (54, matches page's Discovery/Precedence H2s); Formats → `Version formats and Tera templates` (41); Schema system → `Version schema system and 22 presets` (43, 22 verified in two page descriptions); Troubleshooting hub → `zerv errors and troubleshooting` (38); GitHub Actions → `Version every GitHub Actions build` (41). All 11 changed pages got `sidebarTitle` = old label.
+
+    | Page                  | Candidate title                                |
+    | --------------------- | ---------------------------------------------- |
+    | Installation          | Install zerv from PyPI, crates.io, or binaries |
+    | Quickstart            | zerv quickstart: first version from git        |
+    | Flow (concept)        | zerv flow: branch-based version automation     |
+    | Version (concept)     | zerv version: manual version pipeline          |
+    | Config file           | zerv.toml config file reference                |
+    | Formats and templates | Version formats and Tera templates             |
+    | Schema system         | Version schema system and 22 presets           |
+    | Troubleshooting hub   | zerv errors and troubleshooting                |
+    | GitHub Actions        | Version every GitHub Actions build             |
+
+- [x] A5. Sweep: every rendered title unique; no page where title + suffix duplicates the brand word (`X - zerv - zerv` pattern). Verified 2026-08-24: all 17 rendered titles unique (min 15, max 54 chars); the two exact-brand duplicates (index, cli/zerv) fixed in A2/A3; `bake docs-check` clean.
+
+## Phase B — troubleshooting split
+
+- [x] B1. Read `docs/troubleshooting/index.mdx` in full; confirm the 5-error / 4-behavioral classification before splitting
+- [x] B2. Create 5 per-error pages under `docs/troubleshooting/`:
+    - `title` = exact error string as the CLI emits it (verbatim — these match paste-into-Google queries)
+    - short `sidebarTitle`
+    - body: exact error, cause, fix, code examples (test-backed per docs standards where examples exist)
+    - Pages: `No version tags are reachable from HEAD`, `VCS not found: git`, `Unknown schema`, `Conflicting options`, `Config parse error`
+
+    Done 2026-08-24. Deviation from the locked page list: the VCS page title is
+    `VCS not found: Not in a git repository` (quoted, has `: `), not `VCS not found: git` — the
+    hub's old string was wrong; every production construction site emits payload
+    `Not in a git repository (--source git)` (`src/vcs/git.rs:89`, `src/vcs/mod.rs:44`,
+    `mod.rs:99`). Verbatim rule wins. All 5 pages carry reproduce-blocks backed by existing
+    tests: git.rs (`test_git_source_no_tag_version`, `test_git_source_not_a_git_repo`),
+    none.rs (`test_none_source_with_distance`), docs/troubleshooting.rs (unknown schema,
+    conflicting options), config_file/mod.rs (`unknown_field_errors_loud`,
+    `malformed_config_errors_loud`). Frontmatter `description` values needed double quotes
+    (all contain `zerv error: ...`).
+
+- [x] B3. Hub keeps the 4 behavioral sections (help-and-exits, PEP440 vs SemVer output, Docker rejects `+`, stdin piping); links all 5 error pages with the error strings as anchor text
+- [x] B4. Wire new pages into `docs.json` navigation (troubleshooting group)
+- [x] B5. Check existing inbound links to the hub still resolve (README, other docs pages deep-linking `troubleshooting#anchors`) — only inbound link is `README.md:86` → `https://zerv.wisl.dev/troubleshooting` (no anchor); zero `troubleshooting#` anchor links repo-wide. Safe. Verified live: all 5 pages 200 + render titles, sidebar shows all 6 entries, hub errors index renders, `bake docs-check` clean.
+
+## Phase C — comparison + internal links
+
+- [x] C1. `getting-started/why-zerv.mdx`: verify comparison sections actually cover semantic-release, setuptools-scm, and git describe (README claims all three) — coverage was 1-bullet thin for setuptools-scm and git describe; now full per-tool H2 sections. README lines 35 + 80 updated to list dunamai too.
+- [x] C2. Add dunamai section: honest table row + short paragraph (Python library, PEP440-centric, no CLI — state real differences, no strawman)
+
+    Done 2026-08-24, with correction: the task note "no CLI" was wrong — dunamai ships a
+    console script (`dunamai from git`, `dunamai check`; verified against
+    github.com/mtkennerly/dunamai). Honest differences written: Python env vs static Rust
+    binary; dunamai supports more VCSs (Mercurial, Subversion, Fossil, …); dunamai pre-release
+    comes from the last tag (branch only as `{branch}` format substitution) vs `zerv flow`
+    branch-pattern→label+number; ZERV RON payload re-render vs one string per invocation.
+    Summary table added under "When to reach for something else" with all four rows.
+
+- [x] C3. Query-shaped H2s on comparison sections (`zerv vs semantic-release`, etc.) — `zerv vs semantic-release` (renamed from "Both tools in one repository"), `zerv vs setuptools-scm`, `zerv vs dunamai`, `zerv vs git describe`. All verified rendering live.
+- [x] C4. Internal-link audit: no orphan pages (content-body links only — footer/sidebar don't count), descriptive first-mention anchors, links in both directions — audit script (md links + Card hrefs, frontmatter/test-comments stripped) over 22 pages. Fixed: 5 error pages now link back to hub (bidirectional); quickstart "Where to go next" links `/cli/zerv`. Remaining orphan: homepage only (nav root — accepted exception). Anchors spot-checked descriptive. `bake docs-check` clean.
+
+## Phase D — verify + ship
+
+- [ ] D1. `bake docs-check`
+- [ ] D2. Docs test sweep for touched examples: `ZERV_TEST_NATIVE_GIT=false ZERV_TEST_DOCKER=true cargo +nightly test --test integration -- docs`
+- [ ] D3. Open single PR, review, merge
+- [ ] D4. Post-deploy curl checks: homepage title, `og:image` host is `zerv.wisl.dev`, `cli/zerv` title, sitemap page count 17 → 22
+- [ ] D5. GSC URL inspection on new error pages and `/skill.md` (`seo.indexing` defaults to `navigable` and `skill.md` is not in nav — if not indexed, decide between `seo.indexing: "all"` or accepting non-indexed)
+
+## Off-repo (user actions, no PR)
+
+- [ ] GSC: submit `https://zerv.wisl.dev/sitemap.xml` (Sitemaps page)
+- [ ] Confirm Bing Webmaster copied the sitemap via GSC import
+- [ ] ~2026-09-07: pull GSC baseline (indexed pages, impressions, queries)
+
+## Verification commands
+
+```bash
+bake docs-check
+curl -s https://zerv.wisl.dev/ | grep '<title>'              # rendered title
+curl -s https://zerv.wisl.dev/ | grep 'og:image'             # og image host
+curl -s https://zerv.wisl.dev/sitemap.xml | grep -c '<loc>'  # page count
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Documentation: **[zerv.wisl.dev](https://zerv.wisl.dev)**
 - **Two modes** - [`zerv flow`](https://zerv.wisl.dev/concepts/flow) automates pre-release management from Git branch patterns; [`zerv version`](https://zerv.wisl.dev/concepts/version) gives full manual control with schemas, overrides, and templates.
 - **Any output format** - SemVer, PEP440, CalVer, or [Tera templates](https://zerv.wisl.dev/concepts/formats-and-templates). Generate every format your pipelines need from a single ZERV RON payload.
 
-See how zerv compares to semantic-release, setuptools-scm, and `git describe` in [Why zerv](https://zerv.wisl.dev/getting-started/why-zerv).
+See how zerv compares to semantic-release, setuptools-scm, dunamai, and `git describe` in [Why zerv](https://zerv.wisl.dev/getting-started/why-zerv).
 
 ## Installation
 
@@ -77,7 +77,7 @@ Fan one ZERV RON payload out to every format your pipelines need in the [quickst
 
 Full documentation lives at [zerv.wisl.dev](https://zerv.wisl.dev):
 
-- [Why zerv](https://zerv.wisl.dev/getting-started/why-zerv) - positioning vs semantic-release, setuptools-scm, `git describe`
+- [Why zerv](https://zerv.wisl.dev/getting-started/why-zerv) - positioning vs semantic-release, setuptools-scm, dunamai, `git describe`
 - [Quickstart](https://zerv.wisl.dev/getting-started/quickstart) - one ZERV RON payload to every format
 - [Concepts](https://zerv.wisl.dev/concepts/flow) - flow, version, schema system, formats and templates, config file
 - [CI/CD](https://zerv.wisl.dev/cicd/github-actions) - GitHub Actions usage, coexisting with semantic-release

--- a/docs/cicd/github-actions.mdx
+++ b/docs/cicd/github-actions.mdx
@@ -1,5 +1,6 @@
 ---
-title: GitHub Actions
+title: Version every GitHub Actions build
+sidebarTitle: GitHub Actions
 description: Version every CI build with the reusable zerv-versioning workflow. One call, every format as outputs.
 ---
 

--- a/docs/cli/zerv.mdx
+++ b/docs/cli/zerv.mdx
@@ -1,5 +1,6 @@
 ---
-title: zerv
+title: zerv CLI commands and global flags
+sidebarTitle: zerv
 description: The zerv root command. Global flags, subcommands, and where AI agents find the docs.
 ---
 

--- a/docs/concepts/config-file.mdx
+++ b/docs/concepts/config-file.mdx
@@ -1,5 +1,6 @@
 ---
-title: Config file
+title: "zerv.toml config file: discovery and precedence"
+sidebarTitle: Config file
 description: Commit your repo's version policy to zerv.toml once. Shared by version and flow; CLI flags still win.
 ---
 

--- a/docs/concepts/flow.mdx
+++ b/docs/concepts/flow.mdx
@@ -1,5 +1,6 @@
 ---
-title: Flow
+title: "zerv flow: branch-based versioning automation"
+sidebarTitle: Flow
 description: How zerv flow turns any Git state into a meaningful pre-release version. Branch patterns, post modes, dirty state, and build context.
 ---
 

--- a/docs/concepts/formats-and-templates.mdx
+++ b/docs/concepts/formats-and-templates.mdx
@@ -1,5 +1,6 @@
 ---
-title: Formats and templates
+title: Version formats and Tera templates
+sidebarTitle: Formats and templates
 description: Output formats (SemVer, PEP440, ZERV RON), the ZERV_RON piping pattern, and the Tera template system with all variables and functions.
 ---
 

--- a/docs/concepts/schema-system.mdx
+++ b/docs/concepts/schema-system.mdx
@@ -1,5 +1,6 @@
 ---
-title: Schema system
+title: Version schema system and 22 presets
+sidebarTitle: Schema system
 description: How zerv assembles a version. Core, extra_core, and build components; 22 presets; and custom RON schemas.
 ---
 

--- a/docs/concepts/version.mdx
+++ b/docs/concepts/version.mdx
@@ -1,5 +1,6 @@
 ---
-title: Version
+title: "zerv version: manual versioning pipeline"
+sidebarTitle: Version
 description: The zerv version pipeline. Input sources, VCS detection, overrides, and bumping. General-purpose version generation without opinionated logic.
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,7 @@
     "seo": {
         "metatags": {
             "canonical": "https://zerv.wisl.dev",
-            "og:image": "/img/brand/og-card-light.png",
+            "og:image": "https://zerv.wisl.dev/img/brand/og-card-light.png",
             "twitter:card": "summary_large_image"
         },
         "organization": {
@@ -123,7 +123,14 @@
             },
             {
                 "group": "Troubleshooting",
-                "pages": ["troubleshooting/index"]
+                "pages": [
+                    "troubleshooting/index",
+                    "troubleshooting/no-version-tags-reachable",
+                    "troubleshooting/vcs-not-found",
+                    "troubleshooting/unknown-schema",
+                    "troubleshooting/conflicting-options",
+                    "troubleshooting/config-parse-error"
+                ]
             }
         ]
     }

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,5 +1,6 @@
 ---
-title: Installation
+title: Install zerv from PyPI, crates.io, or binaries
+sidebarTitle: Installation
 description: Install zerv from PyPI, crates.io, or a pre-built binary.
 ---
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
-title: Quickstart
+title: "zerv quickstart: your first version from git"
+sidebarTitle: Quickstart
 description: Run zerv flow in a Git repo, then fan one ZERV RON payload out to every format your pipeline needs.
 ---
 
@@ -76,6 +77,7 @@ echo $ZERV_RON | zerv version --source stdin --output-template "v{{ major | defa
 
 ## Where to go next
 
+- [CLI reference](/cli/zerv) - every command and global flag
 - [Flow](/concepts/flow) - how any Git state becomes a version
 - [Schema system](/concepts/schema-system) - presets and custom RON schemas
 - [Formats and templates](/concepts/formats-and-templates) - output formats and Tera templates

--- a/docs/getting-started/why-zerv.mdx
+++ b/docs/getting-started/why-zerv.mdx
@@ -1,6 +1,6 @@
 ---
 title: Why zerv
-description: zerv runs next to semantic-release. semantic-release versions releases on main; zerv versions every other branch, PR, and dirty working tree.
+description: zerv vs semantic-release, setuptools-scm, dunamai, and git describe - which versioning tool fits, and how zerv versions every branch, PR, and dirty working tree.
 ---
 
 zerv is designed to run next to semantic-release, not instead of it. Split the work by
@@ -25,7 +25,7 @@ exact Git state?*
   CalVer, docker tags, `v`-prefixed major tags. Anything expressible as a schema or Tera
   template.
 
-## Both tools in one repository
+## zerv vs semantic-release
 
 zerv's own repository runs both in its CD pipeline
 ([`cd.yml`](https://github.com/wislertt/zerv/blob/main/.github/workflows/cd.yml)):
@@ -68,11 +68,48 @@ echo $ZERV_RON | zerv version --source stdin --output-format pep440
 
 {/* Corresponding test: tests/integration_tests/flow/docs/quick_start.rs:test_quick_start_shared_zerv_versioning_github_actions_documentation_examples */}
 
+## zerv vs setuptools-scm
+
+[setuptools-scm](https://github.com/pypa/setuptools-scm) versions Python packages at build
+time: the build backend reads Git state and writes the version into the package metadata.
+That is the right tool when the package itself is the only artifact.
+
+zerv versions every build in CI — Docker images, deployment manifests, Rust crates, npm
+packages — from the same Git state, with no Python build in the loop. If your pipeline
+only ever needs the version inside package metadata, stay with setuptools-scm.
+
+## zerv vs dunamai
+
+[dunamai](https://github.com/mtkennerly/dunamai) is the closest tool in spirit: a Python
+library and CLI that produces standards-compliant versions from VCS tags, with an
+opinionated PEP 440 default. It even supports more version control systems than zerv
+(Mercurial, Subversion, Fossil, among others).
+
+The differences show up in CI for mixed stacks:
+
+- **Runtime** - zerv is one static Rust binary; dunamai needs a Python environment.
+- **Branch semantics** - [`zerv flow`](/concepts/flow) derives the pre-release label and
+  number from branch patterns (`develop` → beta, `release/*` → rc); dunamai's pre-release
+  comes from the last tag, with the branch available only as a `{branch}` substitution in
+  custom formats.
+- **Output model** - zerv can emit a [ZERV RON payload](/concepts/version) once and
+  re-render it into every format downstream; each dunamai invocation produces one string.
+
+## zerv vs git describe
+
+`git describe` needs no install and prints `v1.0.0-5-gabc1234` — distance and commit from
+the nearest tag. If that raw string is all your pipeline needs, use it.
+
+zerv starts where that shape stops: it parses the tag into version fields, normalizes to
+SemVer or PEP 440, derives pre-release segments from branch patterns
+([flow](/concepts/flow)), and renders through [schemas and Tera
+templates](/concepts/formats-and-templates).
+
 ## When to reach for something else
 
-- You want commit-message parsing, changelogs, and publishing in one tool: use
-  **semantic-release**, or run [both](/cicd/semantic-release).
-- You only need a version inside a Python package build: **setuptools-scm** already lives
-  in that ecosystem.
-- You need a zero-install answer on a bare machine: `git describe` is always there, as
-  long as its `v1.0.0-5-gabc1234` shape is acceptable.
+| Tool | Best at | Reach for it when |
+| --- | --- | --- |
+| [semantic-release](/cicd/semantic-release) | release automation on main | you want changelogs, tags, and publishing from commit messages |
+| [setuptools-scm](https://github.com/pypa/setuptools-scm) | Python package builds | the version only needs to exist inside the package metadata |
+| [dunamai](https://github.com/mtkennerly/dunamai) | Python version detection | a Python-first project where tag + distance + dirty is enough |
+| `git describe` | zero-install version string | its `v1.0.0-5-gabc1234` shape is acceptable |

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: zerv
+title: Dynamic versioning from git for every commit
+sidebarTitle: zerv
 description: Dynamic versioning from git. Every commit gets its version.
 ---
 
@@ -7,12 +8,14 @@ description: Dynamic versioning from git. Every commit gets its version.
     src="/img/brand/og-card-light.png"
     className="sd-hero sd-hero-light"
     alt="Dynamic versioning from git. Every commit gets its version."
+    noZoom
 />
 
 <img
     src="/img/brand/og-card-dark.png"
     className="sd-hero sd-hero-dark"
     alt="Dynamic versioning from git. Every commit gets its version."
+    noZoom
 />
 
 <div className="not-prose sd-badges">
@@ -20,28 +23,27 @@ description: Dynamic versioning from git. Every commit gets its version.
         <img
             src="https://img.shields.io/github/actions/workflow/status/wislertt/zerv/cd.yml?branch=main&label=tests&logo=github"
             alt="tests"
+            noZoom
         />
     </a>
     <a href="https://codecov.io/gh/wislertt/zerv">
-        <img
-            src="https://codecov.io/gh/wislertt/zerv/graph/badge.svg?token=549GL6LQBX"
-            alt="codecov"
-        />
+        <img src="https://codecov.io/gh/wislertt/zerv/graph/badge.svg?token=549GL6LQBX" alt="codecov" noZoom />
     </a>
     <a href="https://crates.io/crates/zerv">
-        <img src="https://img.shields.io/crates/v/zerv?color=green" alt="crates.io" />
+        <img src="https://img.shields.io/crates/v/zerv?color=green" alt="crates.io" noZoom />
     </a>
     <a href="https://pypi.python.org/pypi/zerv-version">
-        <img src="https://img.shields.io/pypi/v/zerv-version.svg?color=blue" alt="pypi" />
+        <img src="https://img.shields.io/pypi/v/zerv-version.svg?color=blue" alt="pypi" noZoom />
     </a>
     <a href="https://github.com/wislertt/zerv/">
         <img
             src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue?logo=python"
             alt="python versions"
+            noZoom
         />
     </a>
     <a href="https://pypi.python.org/pypi/zerv-version">
-        <img src="https://img.shields.io/pypi/l/zerv-version" alt="license" />
+        <img src="https://img.shields.io/pypi/l/zerv-version" alt="license" noZoom />
     </a>
 </div>
 

--- a/docs/troubleshooting/config-parse-error.mdx
+++ b/docs/troubleshooting/config-parse-error.mdx
@@ -1,0 +1,39 @@
+---
+title: Config parse error
+sidebarTitle: Config parse error
+description: "zerv error: Config parse error — zerv.toml has a typo'd or misplaced key. deny_unknown_fields rejects it loudly; fix the key or move it under [version] or [flow]."
+---
+
+```
+Error: Config parse error: ...
+```
+
+`zerv.toml` failed to parse. The file only accepts stable policy fields: an ephemeral
+per-build flag (`dirty = true`, `bump_minor = true`, `major = 2`) or a typo'd key is
+rejected loudly at parse time (`deny_unknown_fields`) rather than silently ignored.
+
+## Triggers
+
+A top-level key that belongs to a section, or does not exist at all:
+
+```toml
+# zerv.toml — rejected: bump_minor is an ephemeral CLI flag, not a config field
+bump_minor = true
+```
+
+{/* Corresponding test: tests/integration_tests/config_file/mod.rs:unknown_field_errors_loud */}
+
+Broken TOML syntax fails the same way, with the error naming `zerv.toml`:
+
+```toml
+# zerv.toml — rejected: not valid TOML
+not = valid = toml
+```
+
+{/* Corresponding test: tests/integration_tests/config_file/mod.rs:malformed_config_errors_loud */}
+
+## Fix
+
+Remove the key, or move it to the matching section (`[version]` / `[flow]`). See the
+[config file](/concepts/config-file) page for the allowed fields. Not this error? Every fix
+lives on [zerv errors and troubleshooting](/troubleshooting).

--- a/docs/troubleshooting/conflicting-options.mdx
+++ b/docs/troubleshooting/conflicting-options.mdx
@@ -1,0 +1,31 @@
+---
+title: Conflicting options
+sidebarTitle: Conflicting options
+description: "zerv error: Conflicting options — two flags that cannot combine, such as --output-template with --output-prefix. Pick one or fold the prefix into the template."
+---
+
+```
+Error: Conflicting options: Cannot use --output-template with --output-prefix. ...
+```
+
+Two flags that say incompatible things about the same output. zerv refuses the combination
+rather than guessing which one wins.
+
+## Reproduce
+
+```bash
+zerv render "1.2.3" --output-template "v{{major}}" --output-prefix "v"
+# Error: Conflicting options: Cannot use --output-template with --output-prefix. ...
+```
+
+{/* Corresponding test: tests/integration_tests/docs/troubleshooting.rs:test_troubleshooting_conflicting_options_message */}
+
+## The common pairs
+
+- `--output-prefix` with `--output-template`: put the prefix inside the template instead,
+  `--output-template "v{{ major }}.{{ minor }}"`
+- `--clean` with `--dirty`: pick one state
+
+See [formats and templates](/concepts/formats-and-templates) for how templates and prefixes
+actually compose. Not this error? Every fix lives on
+[zerv errors and troubleshooting](/troubleshooting).

--- a/docs/troubleshooting/index.mdx
+++ b/docs/troubleshooting/index.mdx
@@ -1,34 +1,18 @@
 ---
-title: Troubleshooting
-description: Fixes for common zerv errors - no reachable tags, VCS not found, unknown schemas, conflicting options, config parse errors, and PEP440 normalization confusion.
+title: zerv errors and troubleshooting
+sidebarTitle: Troubleshooting
+description: zerv behavior that looks wrong but isn't - bare zerv exits 2, PEP440 differs from SemVer, docker rejects +, stdin piping rules. Plus an index of every error fix.
 ---
 
-## No version tags are reachable from HEAD
+## Errors
 
-```
-Error: No version tags are reachable from HEAD
-```
+Every error gets its own page with the exact message, the cause, and the fix:
 
-zerv versions builds relative to the latest reachable tag; a repo (or branch) without any
-tag has no base version. Fixes:
-
-- Create the first tag: `git tag v0.1.0 && git push origin v0.1.0`
-- Seed the base version explicitly: `zerv flow --tag-version "v0.1.0"`
-- In CI, check out with full history: a shallow clone (`fetch-depth: 1`) can cut the tags
-  off. zerv's [reusable workflow](/cicd/github-actions) uses `fetch-depth: 0` for exactly
-  this reason.
-
-## VCS not found: git
-
-```
-Error: VCS not found: git
-```
-
-zerv could not find a Git repository at the working directory. Fixes:
-
-- Run from inside the repository, or point at it: `zerv version -C /path/to/repo`
-- Versioning something that is not a repo (a plain artifact, a manual value)? Skip VCS
-  entirely: `zerv version --source none --tag-version 1.2.3 --distance 5`
+- [No version tags are reachable from HEAD](/troubleshooting/no-version-tags-reachable)
+- [VCS not found: Not in a git repository](/troubleshooting/vcs-not-found)
+- [Unknown schema](/troubleshooting/unknown-schema)
+- [Conflicting options](/troubleshooting/conflicting-options)
+- [Config parse error](/troubleshooting/config-parse-error)
 
 ## Running `zerv` shows help and exits
 
@@ -40,52 +24,6 @@ zerv version
 ```
 
 {/* Corresponding test: tests/integration_tests/help_flags.rs:test_no_subcommand_shows_help_and_exits_nonzero */}
-
-## Unknown schema
-
-```
-Error: Unknown schema: standard-bse
-```
-
-Typo'd or unsupported `--schema` name. Preset names come from the built-in list; see
-[schema system](/concepts/schema-system). For anything custom, write a RON schema instead:
-
-```bash
-zerv version --schema-ron '(core:[var(Major), var(Minor), var(Patch)], extra_core:[], build:[])'
-```
-
-{/* Corresponding test: tests/integration_tests/docs/troubleshooting.rs:test_troubleshooting_unknown_schema_message */}
-
-## Conflicting options
-
-```
-Error: Conflicting options: ...
-```
-
-Two flags that cannot combine. The common ones:
-
-- `--output-prefix` with `--output-template`: put the prefix inside the template instead,
-  `--output-template "v{{ major }}.{{ minor }}"`
-- `--clean` with `--dirty`: pick one state
-
-```bash
-zerv render "1.2.3" --output-template "v{{major}}" --output-prefix "v"
-# Error: Conflicting options: Cannot use --output-template with --output-prefix. ...
-```
-
-{/* Corresponding test: tests/integration_tests/docs/troubleshooting.rs:test_troubleshooting_conflicting_options_message */}
-
-## Config parse error
-
-```
-Error: Config parse error: ...
-```
-
-`zerv.toml` failed to parse. The file only accepts stable policy fields: an ephemeral
-per-build flag (`dirty = true`, `bump_minor = true`, `major = 2`) or a typo'd key is
-rejected loudly at parse time (`deny_unknown_fields`) rather than silently ignored. Remove
-the key or move it to the matching section (`[version]` / `[flow]`). See the
-[config file](/concepts/config-file) page for the allowed fields.
 
 ## PEP440 output looks different from SemVer output
 

--- a/docs/troubleshooting/no-version-tags-reachable.mdx
+++ b/docs/troubleshooting/no-version-tags-reachable.mdx
@@ -1,0 +1,36 @@
+---
+title: No version tags are reachable from HEAD
+sidebarTitle: No reachable tags
+description: "zerv error: No version tags are reachable from HEAD — no tag to version from. Tag the repo, seed --tag-version, or fetch full history in CI."
+---
+
+```
+Error: No version tags are reachable from HEAD
+```
+
+zerv versions every build relative to the latest tag reachable from `HEAD`. A repository —
+or branch — with no tags has no base version, so zerv stops instead of inventing `0.0.0`.
+
+## Reproduce
+
+Any commit in a repo that has no tags yet:
+
+```bash
+zerv version --source git
+# Error: No version tags are reachable from HEAD
+```
+
+{/* Corresponding test: tests/integration_tests/version/main/sources/git.rs:test_git_source_no_tag_version */}
+
+## Fix
+
+- **Create the first tag**: `git tag v0.1.0 && git push origin v0.1.0`
+- **Seed the base version explicitly** when tagging is not yours to do:
+  `zerv flow --tag-version "v0.1.0"`
+- **In CI, check out with full history**: a shallow clone (`fetch-depth: 1`) can cut the tags
+  off. zerv's [reusable workflow](/cicd/github-actions) uses `fetch-depth: 0` for exactly
+  this reason.
+
+See the [version CLI](/cli/version) for every override that can stand in for VCS-detected
+values. Not this error? Every fix lives on
+[zerv errors and troubleshooting](/troubleshooting).

--- a/docs/troubleshooting/unknown-schema.mdx
+++ b/docs/troubleshooting/unknown-schema.mdx
@@ -1,0 +1,34 @@
+---
+title: Unknown schema
+sidebarTitle: Unknown schema
+description: "zerv error: Unknown schema — the --schema preset name is typo'd or unsupported. Use one of the 22 built-in presets or define a custom RON schema."
+---
+
+```
+Error: Unknown schema: standard-bse
+```
+
+The `--schema` value is not a built-in preset name. Preset names come from the built-in
+list in the [schema system](/concepts/schema-system) — most often this error is a typo
+(`standard-bse` for `standard-semver`).
+
+## Reproduce
+
+```bash
+zerv version --source none --tag-version 1.0.0 --schema standard-bse
+# Error: Unknown schema: standard-bse
+```
+
+{/* Corresponding test: tests/integration_tests/docs/troubleshooting.rs:test_troubleshooting_unknown_schema_message */}
+
+## Fix
+
+- **Use a built-in preset**: `--schema standard-semver`, `--schema pep440`, and the rest of
+  the [22 presets](/concepts/schema-system)
+- **For anything custom, write a RON schema** instead of a preset name:
+
+```bash
+zerv version --schema-ron '(core:[var(Major), var(Minor), var(Patch)], extra_core:[], build:[])'
+```
+
+Not this error? Every fix lives on [zerv errors and troubleshooting](/troubleshooting).

--- a/docs/troubleshooting/vcs-not-found.mdx
+++ b/docs/troubleshooting/vcs-not-found.mdx
@@ -1,0 +1,35 @@
+---
+title: "VCS not found: Not in a git repository"
+sidebarTitle: VCS not found
+description: "zerv error: VCS not found: Not in a git repository. zerv ran outside a repo. Run inside it, point -C at it, or skip VCS with --source none."
+---
+
+```
+Error: VCS not found: Not in a git repository (--source git)
+```
+
+zerv could not find a Git repository at — or above — the working directory. It walks parent
+directories looking for a repository, and this error means the walk came up empty.
+
+## Reproduce
+
+```bash
+zerv version --source git
+# Error: VCS not found: Not in a git repository (--source git)
+```
+
+{/* Corresponding test: tests/integration_tests/version/main/sources/git.rs:test_git_source_not_a_git_repo */}
+
+## Fix
+
+- **Run from inside the repository**, or point at it: `zerv version -C /path/to/repo`
+- **Versioning something that is not a repo** (a plain artifact, a manual value)? Skip VCS
+  entirely:
+
+```bash
+zerv version --source none --tag-version 1.2.3 --distance 5
+```
+
+{/* Corresponding test: tests/integration_tests/version/main/sources/none.rs:test_none_source_with_distance */}
+
+Not this error? Every fix lives on [zerv errors and troubleshooting](/troubleshooting).


### PR DESCRIPTION
## What

One PR for the full docs-site SEO pass (task list in `.dev/active/01-docs-seo/`).

### Phase A — meta
- Unique query-shaped titles on 11 pages; `sidebarTitle` keeps the short labels; homepage title states the product (`Dynamic versioning from git for every commit`)
- `og:image` absolute URL (was relative, resolved against mintlify.app host)

### Phase B — troubleshooting split (17 → 22 pages)
- 5 CLI errors become standalone pages, `title` = verbatim error string (matches paste-into-Google queries): [no version tags reachable](https://zerv.wisl.dev/troubleshooting/no-version-tags-reachable), [VCS not found](https://zerv.wisl.dev/troubleshooting/vcs-not-found), [unknown schema](https://zerv.wisl.dev/troubleshooting/unknown-schema), [conflicting options](https://zerv.wisl.dev/troubleshooting/conflicting-options), [config parse error](https://zerv.wisl.dev/troubleshooting/config-parse-error)
- One factual fix found en route: real CLI emits `VCS not found: Not in a git repository (--source git)`, the hub previously claimed `VCS not found: git`
- Hub keeps the 4 behavioral sections + error index

### Phase C — comparisons + internal links
- `why-zerv`: per-tool `zerv vs X` H2 sections (semantic-release, setuptools-scm, dunamai, git describe) + summary table; honest dunamai comparison, verified against upstream (dunamai does ship a CLI)
- README comparison claims updated to match
- Internal-link audit: error pages ↔ hub, quickstart → CLI reference; no orphans except homepage

### Also
- Badge/hero images get `noZoom` (Mintlify click-zoom disabled)

## Verification
- `bake docs-check` clean (no broken links)
- Docs test sweep: `ZERV_TEST_NATIVE_GIT=false ZERV_TEST_DOCKER=true cargo +nightly test --test integration -- docs` → 62 passed, 0 failed
- Frontmatter YAML validated on every touched page; all new pages render on dev server (titles + sidebar verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)