### PR TITLE
docs: SEO pass - titles, troubleshooting split, tool comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Documentation: **[zerv.wisl.dev](https://zerv.wisl.dev)**
 - **Two modes** - [`zerv flow`](https://zerv.wisl.dev/concepts/flow) automates pre-release management from Git branch patterns; [`zerv version`](https://zerv.wisl.dev/concepts/version) gives full manual control with schemas, overrides, and templates.
 - **Any output format** - SemVer, PEP440, CalVer, or [Tera templates](https://zerv.wisl.dev/concepts/formats-and-templates). Generate every format your pipelines need from a single ZERV RON payload.
 
-See how zerv compares to semantic-release, setuptools-scm, and `git describe` in [Why zerv](https://zerv.wisl.dev/getting-started/why-zerv).
+See how zerv compares to semantic-release, setuptools-scm, dunamai, and `git describe` in [Why zerv](https://zerv.wisl.dev/getting-started/why-zerv).
 
 ## Installation
 
@@ -77,7 +77,7 @@ Fan one ZERV RON payload out to every format your pipelines need in the [quickst
 
 Full documentation lives at [zerv.wisl.dev](https://zerv.wisl.dev):
 
-- [Why zerv](https://zerv.wisl.dev/getting-started/why-zerv) - positioning vs semantic-release, setuptools-scm, `git describe`
+- [Why zerv](https://zerv.wisl.dev/getting-started/why-zerv) - positioning vs semantic-release, setuptools-scm, dunamai, `git describe`
 - [Quickstart](https://zerv.wisl.dev/getting-started/quickstart) - one ZERV RON payload to every format
 - [Concepts](https://zerv.wisl.dev/concepts/flow) - flow, version, schema system, formats and templates, config file
 - [CI/CD](https://zerv.wisl.dev/cicd/github-actions) - GitHub Actions usage, coexisting with semantic-release

--- a/docs/cicd/github-actions.mdx
+++ b/docs/cicd/github-actions.mdx
@@ -1,5 +1,6 @@
 ---
-title: GitHub Actions
+title: Version every GitHub Actions build
+sidebarTitle: GitHub Actions
 description: Version every CI build with the reusable zerv-versioning workflow. One call, every format as outputs.
 ---
 

--- a/docs/cli/zerv.mdx
+++ b/docs/cli/zerv.mdx
@@ -1,5 +1,6 @@
 ---
-title: zerv
+title: zerv CLI commands and global flags
+sidebarTitle: zerv
 description: The zerv root command. Global flags, subcommands, and where AI agents find the docs.
 ---
 

--- a/docs/concepts/config-file.mdx
+++ b/docs/concepts/config-file.mdx
@@ -1,5 +1,6 @@
 ---
-title: Config file
+title: "zerv.toml config file: discovery and precedence"
+sidebarTitle: Config file
 description: Commit your repo's version policy to zerv.toml once. Shared by version and flow; CLI flags still win.
 ---
 

--- a/docs/concepts/flow.mdx
+++ b/docs/concepts/flow.mdx
@@ -1,5 +1,6 @@
 ---
-title: Flow
+title: "zerv flow: branch-based versioning automation"
+sidebarTitle: Flow
 description: How zerv flow turns any Git state into a meaningful pre-release version. Branch patterns, post modes, dirty state, and build context.
 ---
 

--- a/docs/concepts/formats-and-templates.mdx
+++ b/docs/concepts/formats-and-templates.mdx
@@ -1,5 +1,6 @@
 ---
-title: Formats and templates
+title: Version formats and Tera templates
+sidebarTitle: Formats and templates
 description: Output formats (SemVer, PEP440, ZERV RON), the ZERV_RON piping pattern, and the Tera template system with all variables and functions.
 ---
 

--- a/docs/concepts/schema-system.mdx
+++ b/docs/concepts/schema-system.mdx
@@ -1,5 +1,6 @@
 ---
-title: Schema system
+title: Version schema system and 22 presets
+sidebarTitle: Schema system
 description: How zerv assembles a version. Core, extra_core, and build components; 22 presets; and custom RON schemas.
 ---
 

--- a/docs/concepts/version.mdx
+++ b/docs/concepts/version.mdx
@@ -1,5 +1,6 @@
 ---
-title: Version
+title: "zerv version: manual versioning pipeline"
+sidebarTitle: Version
 description: The zerv version pipeline. Input sources, VCS detection, overrides, and bumping. General-purpose version generation without opinionated logic.
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,7 @@
     "seo": {
         "metatags": {
             "canonical": "https://zerv.wisl.dev",
-            "og:image": "/img/brand/og-card-light.png",
+            "og:image": "https://zerv.wisl.dev/img/brand/og-card-light.png",
             "twitter:card": "summary_large_image"
         },
         "organization": {
@@ -123,7 +123,14 @@
             },
             {
                 "group": "Troubleshooting",
-                "pages": ["troubleshooting/index"]
+                "pages": [
+                    "troubleshooting/index",
+                    "troubleshooting/no-version-tags-reachable",
+                    "troubleshooting/vcs-not-found",
+                    "troubleshooting/unknown-schema",
+                    "troubleshooting/conflicting-options",
+                    "troubleshooting/config-parse-error"
+                ]
             }
         ]
     }

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,5 +1,6 @@
 ---
-title: Installation
+title: Install zerv from PyPI, crates.io, or binaries
+sidebarTitle: Installation
 description: Install zerv from PyPI, crates.io, or a pre-built binary.
 ---
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
-title: Quickstart
+title: "zerv quickstart: your first version from git"
+sidebarTitle: Quickstart
 description: Run zerv flow in a Git repo, then fan one ZERV RON payload out to every format your pipeline needs.
 ---
 
@@ -76,6 +77,7 @@ echo $ZERV_RON | zerv version --source stdin --output-template "v{{ major | defa
 
 ## Where to go next
 
+- [CLI reference](/cli/zerv) - every command and global flag
 - [Flow](/concepts/flow) - how any Git state becomes a version
 - [Schema system](/concepts/schema-system) - presets and custom RON schemas
 - [Formats and templates](/concepts/formats-and-templates) - output formats and Tera templates

--- a/docs/getting-started/why-zerv.mdx
+++ b/docs/getting-started/why-zerv.mdx
@@ -1,6 +1,6 @@
 ---
 title: Why zerv
-description: zerv runs next to semantic-release. semantic-release versions releases on main; zerv versions every other branch, PR, and dirty working tree.
+description: zerv vs semantic-release, setuptools-scm, dunamai, and git describe - which versioning tool fits, and how zerv versions every branch, PR, and dirty working tree.
 ---
 
 zerv is designed to run next to semantic-release, not instead of it. Split the work by
@@ -25,7 +25,7 @@ exact Git state?*
   CalVer, docker tags, `v`-prefixed major tags. Anything expressible as a schema or Tera
   template.
 
-## Both tools in one repository
+## zerv vs semantic-release
 
 zerv's own repository runs both in its CD pipeline
 ([`cd.yml`](https://github.com/wislertt/zerv/blob/main/.github/workflows/cd.yml)):
@@ -68,11 +68,48 @@ echo $ZERV_RON | zerv version --source stdin --output-format pep440
 
 {/* Corresponding test: tests/integration_tests/flow/docs/quick_start.rs:test_quick_start_shared_zerv_versioning_github_actions_documentation_examples */}
 
+## zerv vs setuptools-scm
+
+[setuptools-scm](https://github.com/pypa/setuptools-scm) versions Python packages at build
+time: the build backend reads Git state and writes the version into the package metadata.
+That is the right tool when the package itself is the only artifact.
+
+zerv versions every build in CI — Docker images, deployment manifests, Rust crates, npm
+packages — from the same Git state, with no Python build in the loop. If your pipeline
+only ever needs the version inside package metadata, stay with setuptools-scm.
+
+## zerv vs dunamai
+
+[dunamai](https://github.com/mtkennerly/dunamai) is the closest tool in spirit: a Python
+library and CLI that produces standards-compliant versions from VCS tags, with an
+opinionated PEP 440 default. It even supports more version control systems than zerv
+(Mercurial, Subversion, Fossil, among others).
+
+The differences show up in CI for mixed stacks:
+
+- **Runtime** - zerv is one static Rust binary; dunamai needs a Python environment.
+- **Branch semantics** - [`zerv flow`](/concepts/flow) derives the pre-release label and
+  number from branch patterns (`develop` → beta, `release/*` → rc); dunamai's pre-release
+  comes from the last tag, with the branch available only as a `{branch}` substitution in
+  custom formats.
+- **Output model** - zerv can emit a [ZERV RON payload](/concepts/version) once and
+  re-render it into every format downstream; each dunamai invocation produces one string.
+
+## zerv vs git describe
+
+`git describe` needs no install and prints `v1.0.0-5-gabc1234` — distance and commit from
+the nearest tag. If that raw string is all your pipeline needs, use it.
+
+zerv starts where that shape stops: it parses the tag into version fields, normalizes to
+SemVer or PEP 440, derives pre-release segments from branch patterns
+([flow](/concepts/flow)), and renders through [schemas and Tera
+templates](/concepts/formats-and-templates).
+
 ## When to reach for something else
 
-- You want commit-message parsing, changelogs, and publishing in one tool: use
-  **semantic-release**, or run [both](/cicd/semantic-release).
-- You only need a version inside a Python package build: **setuptools-scm** already lives
-  in that ecosystem.
-- You need a zero-install answer on a bare machine: `git describe` is always there, as
-  long as its `v1.0.0-5-gabc1234` shape is acceptable.
+| Tool | Best at | Reach for it when |
+| --- | --- | --- |
+| [semantic-release](/cicd/semantic-release) | release automation on main | you want changelogs, tags, and publishing from commit messages |
+| [setuptools-scm](https://github.com/pypa/setuptools-scm) | Python package builds | the version only needs to exist inside the package metadata |
+| [dunamai](https://github.com/mtkennerly/dunamai) | Python version detection | a Python-first project where tag + distance + dirty is enough |
+| `git describe` | zero-install version string | its `v1.0.0-5-gabc1234` shape is acceptable |

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: zerv
+title: Dynamic versioning from git for every commit
+sidebarTitle: zerv
 description: Dynamic versioning from git. Every commit gets its version.
 ---
 
@@ -7,12 +8,14 @@ description: Dynamic versioning from git. Every commit gets its version.
     src="/img/brand/og-card-light.png"
     className="sd-hero sd-hero-light"
     alt="Dynamic versioning from git. Every commit gets its version."
+    noZoom
 />
 
 <img
     src="/img/brand/og-card-dark.png"
     className="sd-hero sd-hero-dark"
     alt="Dynamic versioning from git. Every commit gets its version."
+    noZoom
 />
 
 <div className="not-prose sd-badges">
@@ -20,28 +23,27 @@ description: Dynamic versioning from git. Every commit gets its version.
         <img
             src="https://img.shields.io/github/actions/workflow/status/wislertt/zerv/cd.yml?branch=main&label=tests&logo=github"
             alt="tests"
+            noZoom
         />
     </a>
     <a href="https://codecov.io/gh/wislertt/zerv">
-        <img
-            src="https://codecov.io/gh/wislertt/zerv/graph/badge.svg?token=549GL6LQBX"
-            alt="codecov"
-        />
+        <img src="https://codecov.io/gh/wislertt/zerv/graph/badge.svg?token=549GL6LQBX" alt="codecov" noZoom />
     </a>
     <a href="https://crates.io/crates/zerv">
-        <img src="https://img.shields.io/crates/v/zerv?color=green" alt="crates.io" />
+        <img src="https://img.shields.io/crates/v/zerv?color=green" alt="crates.io" noZoom />
     </a>
     <a href="https://pypi.python.org/pypi/zerv-version">
-        <img src="https://img.shields.io/pypi/v/zerv-version.svg?color=blue" alt="pypi" />
+        <img src="https://img.shields.io/pypi/v/zerv-version.svg?color=blue" alt="pypi" noZoom />
     </a>
     <a href="https://github.com/wislertt/zerv/">
         <img
             src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue?logo=python"
             alt="python versions"
+            noZoom
         />
     </a>
     <a href="https://pypi.python.org/pypi/zerv-version">
-        <img src="https://img.shields.io/pypi/l/zerv-version" alt="license" />
+        <img src="https://img.shields.io/pypi/l/zerv-version" alt="license" noZoom />
     </a>
 </div>
 

--- a/docs/troubleshooting/config-parse-error.mdx
+++ b/docs/troubleshooting/config-parse-error.mdx
@@ -1,0 +1,39 @@
+---
+title: Config parse error
+sidebarTitle: Config parse error
+description: "zerv error: Config parse error — zerv.toml has a typo'd or misplaced key. deny_unknown_fields rejects it loudly; fix the key or move it under [version] or [flow]."
+---
+
+```
+Error: Config parse error: ...
+```
+
+`zerv.toml` failed to parse. The file only accepts stable policy fields: an ephemeral
+per-build flag (`dirty = true`, `bump_minor = true`, `major = 2`) or a typo'd key is
+rejected loudly at parse time (`deny_unknown_fields`) rather than silently ignored.
+
+## Triggers
+
+A top-level key that belongs to a section, or does not exist at all:
+
+```toml
+# zerv.toml — rejected: bump_minor is an ephemeral CLI flag, not a config field
+bump_minor = true
+```
+
+{/* Corresponding test: tests/integration_tests/config_file/mod.rs:unknown_field_errors_loud */}
+
+Broken TOML syntax fails the same way, with the error naming `zerv.toml`:
+
+```toml
+# zerv.toml — rejected: not valid TOML
+not = valid = toml
+```
+
+{/* Corresponding test: tests/integration_tests/config_file/mod.rs:malformed_config_errors_loud */}
+
+## Fix
+
+Remove the key, or move it to the matching section (`[version]` / `[flow]`). See the
+[config file](/concepts/config-file) page for the allowed fields. Not this error? Every fix
+lives on [zerv errors and troubleshooting](/troubleshooting).

--- a/docs/troubleshooting/conflicting-options.mdx
+++ b/docs/troubleshooting/conflicting-options.mdx
@@ -1,0 +1,31 @@
+---
+title: Conflicting options
+sidebarTitle: Conflicting options
+description: "zerv error: Conflicting options — two flags that cannot combine, such as --output-template with --output-prefix. Pick one or fold the prefix into the template."
+---
+
+```
+Error: Conflicting options: Cannot use --output-template with --output-prefix. ...
+```
+
+Two flags that say incompatible things about the same output. zerv refuses the combination
+rather than guessing which one wins.
+
+## Reproduce
+
+```bash
+zerv render "1.2.3" --output-template "v{{major}}" --output-prefix "v"
+# Error: Conflicting options: Cannot use --output-template with --output-prefix. ...
+```
+
+{/* Corresponding test: tests/integration_tests/docs/troubleshooting.rs:test_troubleshooting_conflicting_options_message */}
+
+## The common pairs
+
+- `--output-prefix` with `--output-template`: put the prefix inside the template instead,
+  `--output-template "v{{ major }}.{{ minor }}"`
+- `--clean` with `--dirty`: pick one state
+
+See [formats and templates](/concepts/formats-and-templates) for how templates and prefixes
+actually compose. Not this error? Every fix lives on
+[zerv errors and troubleshooting](/troubleshooting).

--- a/docs/troubleshooting/index.mdx
+++ b/docs/troubleshooting/index.mdx
@@ -1,34 +1,18 @@
 ---
-title: Troubleshooting
-description: Fixes for common zerv errors - no reachable tags, VCS not found, unknown schemas, conflicting options, config parse errors, and PEP440 normalization confusion.
+title: zerv errors and troubleshooting
+sidebarTitle: Troubleshooting
+description: zerv behavior that looks wrong but isn't - bare zerv exits 2, PEP440 differs from SemVer, docker rejects +, stdin piping rules. Plus an index of every error fix.
 ---
 
-## No version tags are reachable from HEAD
+## Errors
 
-```
-Error: No version tags are reachable from HEAD
-```
+Every error gets its own page with the exact message, the cause, and the fix:
 
-zerv versions builds relative to the latest reachable tag; a repo (or branch) without any
-tag has no base version. Fixes:
-
-- Create the first tag: `git tag v0.1.0 && git push origin v0.1.0`
-- Seed the base version explicitly: `zerv flow --tag-version "v0.1.0"`
-- In CI, check out with full history: a shallow clone (`fetch-depth: 1`) can cut the tags
-  off. zerv's [reusable workflow](/cicd/github-actions) uses `fetch-depth: 0` for exactly
-  this reason.
-
-## VCS not found: git
-
-```
-Error: VCS not found: git
-```
-
-zerv could not find a Git repository at the working directory. Fixes:
-
-- Run from inside the repository, or point at it: `zerv version -C /path/to/repo`
-- Versioning something that is not a repo (a plain artifact, a manual value)? Skip VCS
-  entirely: `zerv version --source none --tag-version 1.2.3 --distance 5`
+- [No version tags are reachable from HEAD](/troubleshooting/no-version-tags-reachable)
+- [VCS not found: Not in a git repository](/troubleshooting/vcs-not-found)
+- [Unknown schema](/troubleshooting/unknown-schema)
+- [Conflicting options](/troubleshooting/conflicting-options)
+- [Config parse error](/troubleshooting/config-parse-error)
 
 ## Running `zerv` shows help and exits
 
@@ -40,52 +24,6 @@ zerv version
 ```
 
 {/* Corresponding test: tests/integration_tests/help_flags.rs:test_no_subcommand_shows_help_and_exits_nonzero */}
-
-## Unknown schema
-
-```
-Error: Unknown schema: standard-bse
-```
-
-Typo'd or unsupported `--schema` name. Preset names come from the built-in list; see
-[schema system](/concepts/schema-system). For anything custom, write a RON schema instead:
-
-```bash
-zerv version --schema-ron '(core:[var(Major), var(Minor), var(Patch)], extra_core:[], build:[])'
-```
-
-{/* Corresponding test: tests/integration_tests/docs/troubleshooting.rs:test_troubleshooting_unknown_schema_message */}
-
-## Conflicting options
-
-```
-Error: Conflicting options: ...
-```
-
-Two flags that cannot combine. The common ones:
-
-- `--output-prefix` with `--output-template`: put the prefix inside the template instead,
-  `--output-template "v{{ major }}.{{ minor }}"`
-- `--clean` with `--dirty`: pick one state
-
-```bash
-zerv render "1.2.3" --output-template "v{{major}}" --output-prefix "v"
-# Error: Conflicting options: Cannot use --output-template with --output-prefix. ...
-```
-
-{/* Corresponding test: tests/integration_tests/docs/troubleshooting.rs:test_troubleshooting_conflicting_options_message */}
-
-## Config parse error
-
-```
-Error: Config parse error: ...
-```
-
-`zerv.toml` failed to parse. The file only accepts stable policy fields: an ephemeral
-per-build flag (`dirty = true`, `bump_minor = true`, `major = 2`) or a typo'd key is
-rejected loudly at parse time (`deny_unknown_fields`) rather than silently ignored. Remove
-the key or move it to the matching section (`[version]` / `[flow]`). See the
-[config file](/concepts/config-file) page for the allowed fields.
 
 ## PEP440 output looks different from SemVer output
 

--- a/docs/troubleshooting/no-version-tags-reachable.mdx
+++ b/docs/troubleshooting/no-version-tags-reachable.mdx
@@ -1,0 +1,36 @@
+---
+title: No version tags are reachable from HEAD
+sidebarTitle: No reachable tags
+description: "zerv error: No version tags are reachable from HEAD — no tag to version from. Tag the repo, seed --tag-version, or fetch full history in CI."
+---
+
+```
+Error: No version tags are reachable from HEAD
+```
+
+zerv versions every build relative to the latest tag reachable from `HEAD`. A repository —
+or branch — with no tags has no base version, so zerv stops instead of inventing `0.0.0`.
+
+## Reproduce
+
+Any commit in a repo that has no tags yet:
+
+```bash
+zerv version --source git
+# Error: No version tags are reachable from HEAD
+```
+
+{/* Corresponding test: tests/integration_tests/version/main/sources/git.rs:test_git_source_no_tag_version */}
+
+## Fix
+
+- **Create the first tag**: `git tag v0.1.0 && git push origin v0.1.0`
+- **Seed the base version explicitly** when tagging is not yours to do:
+  `zerv flow --tag-version "v0.1.0"`
+- **In CI, check out with full history**: a shallow clone (`fetch-depth: 1`) can cut the tags
+  off. zerv's [reusable workflow](/cicd/github-actions) uses `fetch-depth: 0` for exactly
+  this reason.
+
+See the [version CLI](/cli/version) for every override that can stand in for VCS-detected
+values. Not this error? Every fix lives on
+[zerv errors and troubleshooting](/troubleshooting).

--- a/docs/troubleshooting/unknown-schema.mdx
+++ b/docs/troubleshooting/unknown-schema.mdx
@@ -1,0 +1,34 @@
+---
+title: Unknown schema
+sidebarTitle: Unknown schema
+description: "zerv error: Unknown schema — the --schema preset name is typo'd or unsupported. Use one of the 22 built-in presets or define a custom RON schema."
+---
+
+```
+Error: Unknown schema: standard-bse
+```
+
+The `--schema` value is not a built-in preset name. Preset names come from the built-in
+list in the [schema system](/concepts/schema-system) — most often this error is a typo
+(`standard-bse` for `standard-semver`).
+
+## Reproduce
+
+```bash
+zerv version --source none --tag-version 1.0.0 --schema standard-bse
+# Error: Unknown schema: standard-bse
+```
+
+{/* Corresponding test: tests/integration_tests/docs/troubleshooting.rs:test_troubleshooting_unknown_schema_message */}
+
+## Fix
+
+- **Use a built-in preset**: `--schema standard-semver`, `--schema pep440`, and the rest of
+  the [22 presets](/concepts/schema-system)
+- **For anything custom, write a RON schema** instead of a preset name:
+
+```bash
+zerv version --schema-ron '(core:[var(Major), var(Minor), var(Patch)], extra_core:[], build:[])'
+```
+
+Not this error? Every fix lives on [zerv errors and troubleshooting](/troubleshooting).

--- a/docs/troubleshooting/vcs-not-found.mdx
+++ b/docs/troubleshooting/vcs-not-found.mdx
@@ -1,0 +1,35 @@
+---
+title: "VCS not found: Not in a git repository"
+sidebarTitle: VCS not found
+description: "zerv error: VCS not found: Not in a git repository. zerv ran outside a repo. Run inside it, point -C at it, or skip VCS with --source none."
+---
+
+```
+Error: VCS not found: Not in a git repository (--source git)
+```
+
+zerv could not find a Git repository at — or above — the working directory. It walks parent
+directories looking for a repository, and this error means the walk came up empty.
+
+## Reproduce
+
+```bash
+zerv version --source git
+# Error: VCS not found: Not in a git repository (--source git)
+```
+
+{/* Corresponding test: tests/integration_tests/version/main/sources/git.rs:test_git_source_not_a_git_repo */}
+
+## Fix
+
+- **Run from inside the repository**, or point at it: `zerv version -C /path/to/repo`
+- **Versioning something that is not a repo** (a plain artifact, a manual value)? Skip VCS
+  entirely:
+
+```bash
+zerv version --source none --tag-version 1.2.3 --distance 5
+```
+
+{/* Corresponding test: tests/integration_tests/version/main/sources/none.rs:test_none_source_with_distance */}
+
+Not this error? Every fix lives on [zerv errors and troubleshooting](/troubleshooting).

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "bakefile"
-version = "0.0.75"
+version = "0.0.76"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautysh" },
@@ -49,9 +49,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/7d/b2b26164f87e828733a47c4ca60219493c256e59dedd60ab65e16ac651ee/bakefile-0.0.75.tar.gz", hash = "sha256:41dea13f33928be0965ba2cd7ec32c7677771feed6c7df37069d75a867540e50", size = 78972, upload-time = "2026-08-24T01:12:55.519Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/e5/2695f31aa86d4e14fd9d6dea85462d63c833956cac0129dbf0e0fa57fc3a/bakefile-0.0.76.tar.gz", hash = "sha256:e2b8aafe7941e6cddc4812921db72fd109069fdaee32d4c7d68454a68330d320", size = 78991, upload-time = "2026-08-25T03:30:54.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/63/fc5da96a52f52d6edc1455060b005e0485b6b9cd7d35cf3c4d8de2583858/bakefile-0.0.75-py3-none-any.whl", hash = "sha256:e6f9b313481f2129cb76c32889774d3d3db98fead638d613f17cbaf9952ab5f8", size = 112286, upload-time = "2026-08-24T01:12:54.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/37/9b67f23f7e4e97eabb8f8f563816527a947a987f6d703f1caacb177f6d25/bakefile-0.0.76-py3-none-any.whl", hash = "sha256:996bec096dd44c073d73fab8809926d8a408fc969aebcbf847a0a0808a23f833", size = 112287, upload-time = "2026-08-25T03:30:53.222Z" },
 ]
 
 [[package]]
@@ -597,26 +597,26 @@ wheels = [
 
 [[package]]
 name = "maturin"
-version = "1.14.1"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/b3/addd877f871fb1860d46d3a4f206ecb10b946c85846805e6367631926fd3/maturin-1.14.1.tar.gz", hash = "sha256:9d6577a62cd08e0ceba7a0db06fb098e0c9b1b3429bad747a4f3a18215a1b3df", size = 369637, upload-time = "2026-06-19T05:19:49.774Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/c8/22e5e21b2679c9bce6415ca578034ca2cc9316be0642ae21e051a2d5198c/maturin-1.15.0.tar.gz", hash = "sha256:94b26cc8e8aba61a5f2099715fe640e18c5f678e9a500408b38761263954228a", size = 385504, upload-time = "2026-08-24T12:11:22.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/f0/97c5a5bd9c71653a066c0976a484eaaae50b9369557838a4176b7b0bdaa5/maturin-1.14.1-py3-none-linux_armv6l.whl", hash = "sha256:522292398945442cdafa9daeb2271b2340fbde57027b818f923f88eab04174f8", size = 10207496, upload-time = "2026-06-19T05:19:09.321Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/83/294bca639b0e052f1e2f65199b3db258780c7d4e31408b934c9c974a1379/maturin-1.14.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ffe5ad71f21d1e6603c4dd75f7fee34adf5ed5ebcebb692886549888ebb329ed", size = 19680113, upload-time = "2026-06-19T05:19:13.43Z" },
-    { url = "https://files.pythonhosted.org/packages/43/b6/79c881410a3b1c187f7eb3d407aecae646c6a4433d630d72200359015e83/maturin-1.14.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3306078070c1508fd715b9116070cbcaff5959024272a9f1e6f5cb29768b86c", size = 10169205, upload-time = "2026-06-19T05:19:16.615Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9d/44b6f26dcb7f7a04c5501ac2dbb6ca1490150682baa525ca5860504f9eab/maturin-1.14.1-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:cd457cd88961156e26379e1155bd287cc0ec1c8b2f1582b0660fb31b87c8842d", size = 10188098, upload-time = "2026-06-19T05:19:19.736Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bd/9c0d5d6983905ce2c9edaa073a7e89355a9cf7f396988e05d32f1c37785d/maturin-1.14.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:dfc54ae32e6fcb18302193ab9a30b0b25eefffba994ae13238974805533ef75e", size = 10627576, upload-time = "2026-06-19T05:19:22.713Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/33/b096412bd6a7cb399652b260666f901adf88a687181a6dbd6a3f89f0a94e/maturin-1.14.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a131d912b5267e640bc96d70f4914e10590aed64082ec9abacba7cea52004224", size = 10085181, upload-time = "2026-06-19T05:19:25.69Z" },
-    { url = "https://files.pythonhosted.org/packages/56/8d/08c3bf469c38a23c9e6c877e338193001eb604d010fedc08341974e38528/maturin-1.14.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:be18fc568fb76884c0205456336892a75105ec398e6b667cd777c6268bd06d69", size = 10026363, upload-time = "2026-06-19T05:19:28.904Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/a4/c4d1a92839f8745ab4aab988a7db884a79d6d710bd3b286fcf9316dece1a/maturin-1.14.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:994a0c8ba3ad8a92b3a9ee1b02645d200d610216b15cff5102b0fe65e8e08666", size = 13321347, upload-time = "2026-06-19T05:19:32.411Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/fa/170f04624d03fd07d2a8b1b67de83a127af93aef9eaa425839553347297b/maturin-1.14.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:be80866363e605d137991b491a741a84cde9ae350183c4c85f49690ca9aaaa65", size = 10877609, upload-time = "2026-06-19T05:19:35.448Z" },
-    { url = "https://files.pythonhosted.org/packages/61/ad/1ae2e1d0ded282bf2c55ac13f0811d87deb425e200ae64a15785675dede9/maturin-1.14.1-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:5282dffd4b539d2be245f4e5b1a5ab6bc1033b58f4a4872f5833f9d43c954aa4", size = 10417316, upload-time = "2026-06-19T05:19:38.28Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/27/bf677183920718da49cd7982d6a3ffc440aad8919329f571d189f81b7bdf/maturin-1.14.1-py3-none-win32.whl", hash = "sha256:1a04de0a20188f95c721b5702eed18140bdcccb28c386797093eca3f62f4d4e0", size = 8931293, upload-time = "2026-06-19T05:19:41.183Z" },
-    { url = "https://files.pythonhosted.org/packages/63/4b/585adeb9167b08d3cdff0032a938b0e72655c92003df4f52c3f696a1bcc2/maturin-1.14.1-py3-none-win_amd64.whl", hash = "sha256:3c9f94640ecc4895e94abaf834a0684430032c865b2748a36c12461fd9252fdd", size = 10314067, upload-time = "2026-06-19T05:19:44.389Z" },
-    { url = "https://files.pythonhosted.org/packages/51/d4/dac8c0720ae246be1700afb6fbdbbea20fe35b13f6570b2f70faa005df77/maturin-1.14.1-py3-none-win_arm64.whl", hash = "sha256:15cea8fcb3ba47dd636f50092bb34baea8b04ac777392f23e6bf8a9a61efb894", size = 9718943, upload-time = "2026-06-19T05:19:47.49Z" },
+    { url = "https://files.pythonhosted.org/packages/14/69/5c01b461044eb1f45ddcce006706eb88110c793cdb11c7ae0b5e08492e94/maturin-1.15.0-py3-none-linux_armv6l.whl", hash = "sha256:6bf6dc62e22d4dcfd5a51244ff0d58975fa4979c48209fe84159617648956d82", size = 10206220, upload-time = "2026-08-24T12:10:53.327Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1f/2b431554e11687cdb1077e0cdadcc118c53f611086b3af00c8545a67c6a5/maturin-1.15.0-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:cd35772633f489841132bc8e71d6fc7f842df30b9c05cd5cdf1ee1ddcb744cc7", size = 19416513, upload-time = "2026-08-24T12:10:56.126Z" },
+    { url = "https://files.pythonhosted.org/packages/51/36/e23a21cb34a648b711036b9b2fe1d4f3f4ee24f8db54215d73f1a9a3a3ec/maturin-1.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c40b4eae7bf5ef1f4b1af8d623fe4105016f93578fb15b764e741d08ec3b92dd", size = 10014962, upload-time = "2026-08-24T12:10:58.486Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/80/33b15cb2d8f30f12c807955e8f2fd775027692904e30ec0784744ce8cd83/maturin-1.15.0-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:7eb066372f541f8eb4909c79c5d9bd0b9e8125980bdf1ec9e8aba23c6c8d6c55", size = 10196223, upload-time = "2026-08-24T12:11:00.696Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/91/b495e19e2f5c503b540452b2039115e7b2363867e8c5ad4179eb752fa92c/maturin-1.15.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:653020a63525bb224e5ab0adf02e17a2e08bc86dbea7fc1399c9a56d7529b99e", size = 10541186, upload-time = "2026-08-24T12:11:02.857Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2b/2abff58037188d852b124871b1f0d720e1c2bfb3d4f1b03d87c52cd66488/maturin-1.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:0ebf9767892725083138e671c34482c660317a2f3d6a29fc0e0f34e9d8c99136", size = 10083468, upload-time = "2026-08-24T12:11:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/b7e9f8be99a6627849e81ac7b6694876bce8f50a92995fe17e3cf2610f0a/maturin-1.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:7ab7eebffd7b8debca2265985de4eaeb332141276d24b9560b5ad484d4b3add1", size = 10047786, upload-time = "2026-08-24T12:11:07.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ab/167e3cb7accee11b507dbe53e0e87aeccb376d44ae66284c96ee4df3a9fd/maturin-1.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:126e12e618b4db42f68c779a56d41f82a390145ba36ac3f621d057eb34f5ad9d", size = 13315332, upload-time = "2026-08-24T12:11:09.433Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4d/801379f646cbc6b00998e5289b0630a886be3a4ee4c75b6bc9b87478a7f1/maturin-1.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f9d33e6c3f9615c8caceecbbbd440f8eb25a3ddeb687077682cd5eca2e9ae15", size = 10807183, upload-time = "2026-08-24T12:11:11.73Z" },
+    { url = "https://files.pythonhosted.org/packages/89/27/2e612e1cbd1580e9e94d4722c227b5180dca27b32b955a34b79918aa1292/maturin-1.15.0-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:bf29beddd0c6708f112db51d5275fc28b28b9e9c9c5faae387eaef662918b176", size = 10413274, upload-time = "2026-08-24T12:11:14.04Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/202a7b4d75a51f20f84ec9ce3b7345b12b822207072164e2b1c6ef665125/maturin-1.15.0-py3-none-win32.whl", hash = "sha256:da649988be98e87e009e51b1bf0d301b6a301bc0cecbdd60d40d8ba60748d1ca", size = 8928744, upload-time = "2026-08-24T12:11:16.269Z" },
+    { url = "https://files.pythonhosted.org/packages/40/dc/4e90da594986ba78dd3bc8a5921ecdcdb11085b22b02a412caab3b225601/maturin-1.15.0-py3-none-win_amd64.whl", hash = "sha256:552c2be4afd43fe8d5c9f3ec8d4c4756d973b8dcbe94c14084390301f50243e1", size = 10335085, upload-time = "2026-08-24T12:11:18.326Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/10/15d4314edf130955edf2dc237aa393a8a7c10f2b9b57b89fa2f61f915659/maturin-1.15.0-py3-none-win_arm64.whl", hash = "sha256:c7dc0c66c78d3debdd9c5aa807e861fbcbf07f3505d34b125df74c03986b0f48", size = 9713795, upload-time = "2026-08-24T12:11:20.83Z" },
 ]
 
 [[package]]
@@ -738,11 +738,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.3"
+version = "4.11.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz", hash = "sha256:f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d", size = 34079, upload-time = "2026-08-24T14:53:49.676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
+    { url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl", hash = "sha256:e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586", size = 23741, upload-time = "2026-08-24T14:53:48.406Z" },
 ]
 
 [[package]]
@@ -967,14 +967,14 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.5.2"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/b7/ac44da2cf0e53ada0e419033c2d058219c95dc1403126f163304c9e814b1/python_discovery-1.5.2.tar.gz", hash = "sha256:45fd4f20a4e3f9b7bf2e0817870bc8e3b320a19658da177af800768c82dbf354", size = 82350, upload-time = "2026-08-12T14:05:26.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/8f/3c92c45737f654f2488ab3662b7604a55d3d35146d37c9ce80f5c95b95a6/python_discovery-1.5.3.tar.gz", hash = "sha256:e500eb24025fb7c4876c1fdcfbafd9028a10c71b661aee38cb6fb0de594518c1", size = 82477, upload-time = "2026-08-24T14:48:46.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/45/689603d04b3bb8d7faa00f25c24acef993aab7813b3dbbfc472a459ab0b5/python_discovery-1.5.2-py3-none-any.whl", hash = "sha256:3e338c2d0f15dfaeea57493f4c2c6caebe0e998ea815c30ae8bf8ee21f1112d3", size = 38350, upload-time = "2026-08-12T14:05:25.113Z" },
+    { url = "https://files.pythonhosted.org/packages/30/12/823d9a321904ccfd2969a24b84fdfd1e6614c707ec569c62879bf1dbc6c5/python_discovery-1.5.3-py3-none-any.whl", hash = "sha256:8305296358f1aa2ed302a25b84be7df84fef8ca47c7dce2da63cb7325333044e", size = 38290, upload-time = "2026-08-24T14:48:45.305Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Descriptive SEO titles and descriptions across the docs site (short `sidebarTitle` keeps navigation clean)
- Split troubleshooting into five per-error pages, each with the exact message, cause, reproduce step, and fixes
- Add `zerv vs setuptools-scm` / `dunamai` / `git describe` comparisons to Why zerv
- Update dependencies

## Changes

### 1. Descriptive page titles and descriptions

**`docs/index.mdx`, `docs/cli/zerv.mdx`, `docs/concepts/*.mdx`, `docs/getting-started/*.mdx`, `docs/cicd/github-actions.mdx`**

Every page front matter now carries a search-oriented `title` (e.g. `zerv flow: branch-based versioning automation`, `Install zerv from PyPI, crates.io, or binaries`) plus a `sidebarTitle` so the navigation keeps its old short labels. The landing page is retitled `Dynamic versioning from git for every commit`, and its hero and badge images get `noZoom` so lightbox zoom no longer hijacks clicks. The quickstart next-steps list gains a link to the CLI reference.

### 2. Per-error troubleshooting pages

**`docs/troubleshooting/*.mdx`, `docs/docs.json`**

Five new pages — `no-version-tags-reachable`, `vcs-not-found`, `unknown-schema`, `conflicting-options`, `config-parse-error` — move each error off the old single index into its own page with the exact error output, why it happens, a Reproduce snippet, and the fixes; each keeps its `{/* Corresponding test */}` reference. The index now lists the error pages and keeps only the non-error behaviors (bare `zerv` exits 2, PEP440 rendering vs SemVer, stdin piping rules). `docs.json` registers the five pages under the Troubleshooting group.

### 3. Tool comparisons in Why zerv

**`docs/getting-started/why-zerv.mdx`, `README.md`**

New `zerv vs setuptools-scm`, `zerv vs dunamai`, and `zerv vs git describe` sections covering runtime (static Rust binary vs Python environment), branch semantics (flow-derived pre-release vs last-tag), and output model (one ZERV RON payload re-rendered vs one string per invocation). `Both tools in one repository` is retitled `zerv vs semantic-release`, and the closing "reach for something else" list becomes a comparison table. README positioning links now mention dunamai.

### 4. SEO metadata

**`docs/docs.json`**

`og:image` switched from the relative `/img/brand/og-card-light.png` to the absolute `https://zerv.wisl.dev/img/brand/og-card-light.png` so scrapers resolve it.

`uv.lock` picks up unrelated dependency bumps (bundled churn, not the point of this PR).

## Test plan

- [ ] Docs examples still match their backing tests (`/docs-sync` audit; troubleshooting pages reference `tests/integration_tests/docs/troubleshooting.rs` and `tests/integration_tests/version/main/sources/git.rs`)
- [ ] Site nav shows the five troubleshooting pages with short sidebar titles
- [ ] OG card image resolves at the absolute URL