### PR TITLE
build: universal GH release binaries via wheel extract

### DIFF
--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -26,15 +26,25 @@ jobs:
             matrix:
                 include:
                     - name: linux-x64
-                      os: ubuntu-latest
+                      os: ubuntu-24.04
                       target: x86_64-unknown-linux-gnu
                       artifact_name: zerv
                       asset_name: zerv-x86_64-unknown-linux-gnu
                     - name: linux-arm64
-                      os: ubuntu-latest
+                      os: ubuntu-24.04
                       target: aarch64-unknown-linux-gnu
                       artifact_name: zerv
                       asset_name: zerv-aarch64-unknown-linux-gnu
+                    - name: linux-x64-musl
+                      os: ubuntu-24.04
+                      target: x86_64-unknown-linux-musl
+                      artifact_name: zerv
+                      asset_name: zerv-x86_64-unknown-linux-musl
+                    - name: linux-arm64-musl
+                      os: ubuntu-24.04
+                      target: aarch64-unknown-linux-musl
+                      artifact_name: zerv
+                      asset_name: zerv-aarch64-unknown-linux-musl
                     - name: macos-x64
                       os: macos-latest
                       target: x86_64-apple-darwin
@@ -78,13 +88,10 @@ jobs:
               shell: bash
               run: rustup target add ${{ matrix.target }}
 
-            - name: install-cross-compilation-dependencies
-              if: matrix.target == 'aarch64-unknown-linux-gnu'
+            - name: setup-venv
+              # --no-install-project: skips a redundant crate compile via build isolation
               shell: bash
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y gcc-aarch64-linux-gnu
-                  echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+              run: uv sync --frozen --no-install-project
 
             - name: update-cargo-toml-version
               if: inputs.version != ''
@@ -92,15 +99,26 @@ jobs:
               run: |
                   bake version "${{ inputs.version }}"
 
+            - name: setup-path
+              shell: bash
+              run: |
+                  if [ "$RUNNER_OS" == "Windows" ]; then
+                    echo "${{ github.workspace }}/.venv/Scripts" >> "$GITHUB_PATH"
+                  else
+                    echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
+                  fi
+
             - name: build-binary
-              run: cargo build --release --target ${{ matrix.target }}
+              # wheel-extract build: GH assets share provenance with the PyPI wheels
+              shell: bash
+              run: bake build --target ${{ matrix.target }}
 
             - name: upload-binary-to-release
               if: inputs.upload_to_release == true && inputs.tag != ''
               uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
-                  file: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+                  file: dist/${{ matrix.artifact_name }}
                   asset_name: ${{ matrix.asset_name }}
                   tag: ${{ inputs.tag }}
                   overwrite: true

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -89,9 +89,8 @@ jobs:
               run: rustup target add ${{ matrix.target }}
 
             - name: setup-venv
-              # --no-install-project: skips a redundant crate compile via build isolation
               shell: bash
-              run: uv sync --frozen --no-install-project
+              run: uv sync --frozen
 
             - name: update-cargo-toml-version
               if: inputs.version != ''

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ categories = [
 rust-version = "1.92"
 exclude = ["/.amazonq/", "/.cursor/", "/.dev/", "/.github/", "/scripts/"]
 
+# assets are bare binaries at the versionless name the default pkg-url already probes
+[package.metadata.binstall]
+pkg-fmt = "bin"
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/bakefile.py
+++ b/bakefile.py
@@ -15,80 +15,112 @@ from bakelib.space.lib import BaseLibSpace
 from tests.python.utils import symlink_zerv_to_venv_bin
 
 
+def _wheel_build_command(target: str | None) -> tuple[str, dict[str, str] | None]:
+    cmd = "maturin build --release --strip --out dist/"
+    env: dict[str, str] | None = None
+
+    if target:
+        cmd += f" --target {target}"
+
+    if target and "-linux-" in target:
+        compatibility = "musllinux_1_2" if target.endswith("-musl") else "manylinux_2_17"
+        cmd += f" --zig --compatibility {compatibility}"
+        # zig comes from the venv's python-zig (maturin[zig]); a system maturin would not see it
+        venv_bin = Path(".venv/bin").resolve()
+        env = {"PATH": f"{venv_bin}{os.pathsep}{os.environ['PATH']}"}
+
+    return cmd, env
+
+
+def _build_wheel(ctx: Context, target: str | None) -> None:
+    cmd, env = _wheel_build_command(target)
+    ctx.run(cmd, env=env)
+
+    if target and "-linux-" in target:
+        _check_wheel_glibc(target)
+
+
+def _extract_wheel_binary() -> Path:
+    wheels = list(Path("dist").glob("*.whl"))
+    if len(wheels) != 1:
+        console.error(f"Expected exactly one wheel in dist/, found: {[w.name for w in wheels]}")
+        raise typer.Exit(1)
+
+    with zipfile.ZipFile(wheels[0]) as zf:
+        bins = [
+            name
+            for name in zf.namelist()
+            if name.endswith((".data/scripts/zerv", ".data/scripts/zerv.exe"))
+        ]
+        if len(bins) != 1:
+            console.error(f"Expected one bundled binary in {wheels[0].name}, found: {bins}")
+            raise typer.Exit(1)
+        binary_path = Path("dist") / Path(bins[0]).name
+        binary_path.write_bytes(zf.read(bins[0]))
+
+    binary_path.chmod(0o755)
+    console.success(f"Extracted {binary_path} from {wheels[0].name}")
+    return binary_path
+
+
+def _check_wheel_glibc(target: str | None) -> None:
+    """maturin tags the wheel from --compatibility, not the binary's symbols; enforce the claim."""
+    wheels = list(Path("dist").glob("*.whl"))
+    if len(wheels) != 1:
+        console.error(f"Expected exactly one wheel in dist/, found: {[w.name for w in wheels]}")
+        raise typer.Exit(1)
+
+    with zipfile.ZipFile(wheels[0]) as zf:
+        # bindings = "bin" places the binary in <pkg>.data/scripts/ (find_bin)
+        bins = [
+            name
+            for name in zf.namelist()
+            if name.endswith((".data/scripts/zerv", ".data/scripts/zerv.exe"))
+        ]
+        if len(bins) != 1:
+            console.error(f"Expected one bundled binary in {wheels[0].name}, found: {bins}")
+            raise typer.Exit(1)
+        binary = zf.read(bins[0])
+
+    text = binary.decode("ascii", errors="ignore")
+    versions = {
+        tuple(int(part) for part in match.split("."))
+        for match in re.findall(r"GLIBC_(\d+(?:\.\d+)*)", text)
+    }
+
+    if target and target.endswith("-musl"):
+        if versions:
+            console.error(
+                f"musl wheel {wheels[0].name} must be static but references glibc: "
+                f"{sorted(versions)}"
+            )
+            raise typer.Exit(1)
+        console.success(f"{wheels[0].name}: static, no glibc references")
+    else:
+        highest = max(versions, default=(0,))
+        if highest > (2, 17):
+            console.error(
+                f"{wheels[0].name} claims manylinux_2_17 but binary requires "
+                f"glibc {'.'.join(map(str, highest))}"
+            )
+            raise typer.Exit(1)
+        console.success(
+            f"{wheels[0].name}: max glibc reference "
+            f"{'.'.join(map(str, highest)) if versions else 'none'}"
+        )
+
+
 class PyPIPublisher(_PyPIPublisher):
     """Custom PyPI publisher for zerv that uses maturin instead of uv build."""
 
     _target: str | None = None
 
     def _build_for_publish(self, ctx: Context) -> None:
-        cmd = "maturin build --release --strip --out dist/"
-        env: dict[str, str] | None = None
-
-        if self._target:
-            cmd += f" --target {self._target}"
-
-        if self._target and "-linux-" in self._target:
-            compatibility = "musllinux_1_2" if self._target.endswith("-musl") else "manylinux_2_17"
-            cmd += f" --zig --compatibility {compatibility}"
-            # zig comes from the venv's `python-zig` (maturin[zig]); a system maturin
-            # would not see it, so make sure the venv's bin dir wins
-            venv_bin = Path(".venv/bin").resolve()
-            env = {"PATH": f"{venv_bin}{os.pathsep}{os.environ['PATH']}"}
-
-        ctx.run(cmd, env=env)
-
-        if self._target and "-linux-" in self._target:
-            self._check_wheel_glibc()
+        _build_wheel(ctx, self._target)
 
         # One designated leg also ships the sdist so non-matrix platforms have a fallback
         if self._target == "x86_64-unknown-linux-gnu":
             ctx.run("maturin sdist --out dist/")
-
-    def _check_wheel_glibc(self) -> None:
-        """Fail the publish if the built binary breaks the wheel's platform tag.
-
-        maturin tags the wheel from the --compatibility flag we pass, not from the
-        binary's actual symbol references; this is the enforcement of that claim.
-        """
-        wheels = list(Path("dist").glob("*.whl"))
-        if len(wheels) != 1:
-            console.error(f"Expected exactly one wheel in dist/, found: {[w.name for w in wheels]}")
-            raise typer.Exit(1)
-
-        with zipfile.ZipFile(wheels[0]) as zf:
-            # bindings = "bin" places the binary in <pkg>.data/scripts/ (find_bin)
-            bins = [name for name in zf.namelist() if name.endswith(".data/scripts/zerv")]
-            if len(bins) != 1:
-                console.error(f"Expected one bundled binary in {wheels[0].name}, found: {bins}")
-                raise typer.Exit(1)
-            binary = zf.read(bins[0])
-
-        text = binary.decode("ascii", errors="ignore")
-        versions = {
-            tuple(int(part) for part in match.split("."))
-            for match in re.findall(r"GLIBC_(\d+(?:\.\d+)*)", text)
-        }
-
-        if self._target and self._target.endswith("-musl"):
-            if versions:
-                console.error(
-                    f"musl wheel {wheels[0].name} must be static but references glibc: "
-                    f"{sorted(versions)}"
-                )
-                raise typer.Exit(1)
-            console.success(f"{wheels[0].name}: static, no glibc references")
-        else:
-            highest = max(versions, default=(0,))
-            if highest > (2, 17):
-                console.error(
-                    f"{wheels[0].name} claims manylinux_2_17 but binary requires "
-                    f"glibc {'.'.join(map(str, highest))}"
-                )
-                raise typer.Exit(1)
-            console.success(
-                f"{wheels[0].name}: max glibc reference "
-                f"{'.'.join(map(str, highest)) if versions else 'none'}"
-            )
 
 
 class MyBakebook(RustSpace, PythonSpace, GitHubActionsTools, BaseLibSpace):
@@ -224,6 +256,21 @@ class MyBakebook(RustSpace, PythonSpace, GitHubActionsTools, BaseLibSpace):
     ):
         self._target = target
         return super().publish(registry=registry, token=token, version=version)
+
+    @command(help="Build a release binary for a target triple, extracted from the maturin wheel")
+    def build(
+        self,
+        *,
+        target: Annotated[
+            str | None,
+            typer.Option(
+                help="Rust target triple (e.g., aarch64-apple-darwin, x86_64-pc-windows-msvc)"
+            ),
+        ] = None,
+    ):
+        shutil.rmtree("dist", ignore_errors=True)
+        _build_wheel(self.ctx, target)
+        return _extract_wheel_binary()
 
     def _get_version(self) -> str:
         return self._get_consistent_version((RustSpace, PythonSpace))

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -9,6 +9,7 @@ description: Install zerv from PyPI, crates.io, or a pre-built binary.
 - **PyPI wheel**: Python 3.10 through 3.14. The wheel bundles the compiled binary; no Rust
   toolchain is needed.
 - **crates.io / pre-built binaries**: no runtime dependencies at all.
+- **Operating systems**: Linux (glibc >= 2.17 or musl), macOS 10.12+, Windows x64/arm64.
 
 ## Install
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,9 +16,13 @@ detect_target() {
 
     case "$platform" in
         Linux*)
+            local libc="gnu"
+            if ldd --version 2>&1 | grep -q "musl"; then
+                libc="musl"
+            fi
             case "$arch" in
-                x86_64|amd64) echo "x86_64-unknown-linux-gnu" ;;
-                aarch64|arm64) echo "aarch64-unknown-linux-gnu" ;;
+                x86_64|amd64) echo "x86_64-unknown-linux-$libc" ;;
+                aarch64|arm64) echo "aarch64-unknown-linux-$libc" ;;
                 *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
             esac ;;
         Darwin*)


### PR DESCRIPTION
## Summary

- GH release binaries now build through the same maturin zig pipeline as the PyPI wheels (glibc 2.17 + musl static, stripped), extracted from the wheel so both channels share provenance
- New `bake build --target` command; build-bin matrix grows to 8 legs with musl x64/arm64
- install.sh picks the `-musl` asset on Alpine; `cargo binstall` gets prebuilt-binary metadata
- Document supported OS matrix on the installation page

## Changes

### 1. `bake build` — wheel-extract build command

**`bakefile.py`**

The wheel-build logic moves from `PyPIPublisher._build_for_publish` to module-level helpers (`_build_wheel`, `_check_wheel_glibc`, `_wheel_build_command`), and a new `bake build --target <triple>` command reuses them: it builds the release wheel (zig + `--compatibility manylinux_2_17`/`musllinux_1_2` on linux legs, `--strip` everywhere, glibc-claim check between build and upload) and extracts the bundled binary from `<pkg>.data/scripts/` to `dist/zerv` (`zerv.exe` on windows, exec bit set). One build recipe now serves both PyPI wheels and GH release assets.

### 2. Universal build-bin matrix

**`.github/workflows/build-bin.yml`**

- linux legs pinned to `ubuntu-24.04`; adds `linux-x64-musl` + `linux-arm64-musl` rows (8 legs total, mirroring publish-pypi)
- `install-cross-compilation-dependencies` removed (zig handles aarch64 cross)
- build step replaced by `bake build --target` with a preceding `uv sync --frozen --no-install-project` (tooling env only — skips a redundant crate compile) and venv PATH setup
- upload now ships `dist/<binary>` — same binary pip installs

### 3. install.sh musl detection

**`scripts/install.sh`**

Linux target detection runs `ldd --version | grep -q musl` and picks `*-unknown-linux-musl` triples on musl hosts (e.g. Alpine), so the static asset is downloaded instead of the glibc one.

### 4. cargo-binstall metadata

**`Cargo.toml`**

Adds `[package.metadata.binstall] pkg-fmt = "bin"` — binstall's default pkg-url already probes the versionless `zerv-<triple>[.exe]` release asset names, so `cargo binstall zerv` resolves prebuilt binaries instead of a 5-minute source compile once a crates.io release carries the metadata.

### 5. Docs

**`docs/getting-started/installation.mdx`**

Requirements section gains the OS support line: Linux (glibc >= 2.17 or musl), macOS 10.12+, Windows x64/arm64.

## Test plan

- [x] `bake build` verified for aarch64-apple-darwin (binary runs, `zerv version` OK), x86_64-gnu (max glibc 2.17, stripped), x86_64-musl (static, runs in alpine container), aarch64-gnu (zig cross from macOS)
- [x] Extraction proven against the real 0.8.28 win_arm64 wheel from PyPI (`zerv.exe` member)
- [x] install.sh detection container-tested: alpine → musl, debian-bookworm/rocky9 → gnu
- [x] `cargo binstall --dry-run zerv@0.8.28` resolves the real release asset with default templates
- [x] actionlint, ruff format/check, ty all green
- [ ] CI on this PR exercises all 8 build-bin legs (ci.yml calls build-bin on every PR)